### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-xml-cd.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-xml-cd.yml@v1
     with:
       xml-url: "https://raw.githubusercontent.com/KhronosGroup/OpenXR-Docs/master/specification/registry/xr.xml"
       xml-path: "KhronosRegistry/xr.xml"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "OpenXRGen/OpenXRGen/OpenXRGen.csproj"  # Path to your generator .csproj
       generator-name: "OpenXR"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,26 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.OpenXR
+  project: OpenXRGen/Evergine.Bindings.OpenXR/Evergine.Bindings.OpenXR.csproj
+  target-framework: net10.0
+  runtime-identifier: ""
+
+upstream:
+  kind: http-file
+  language: c
+  project: https://github.com/KhronosGroup/OpenXR-Docs
+  version-from: spec-attribute      # XR_CURRENT_API_VERSION inside xr.xml
+  sources:
+    # Note: OpenXR-Docs still uses `master` as its default branch, unlike Vulkan-Docs.
+    - url: https://raw.githubusercontent.com/KhronosGroup/OpenXR-Docs/master/specification/registry/xr.xml
+      path: KhronosRegistry/xr.xml
+      format: khronos-xml
+
+generator:
+  project: OpenXRGen/OpenXRGen/OpenXRGen.csproj
+  name: OpenXR
+  output:
+    - OpenXRGen/Evergine.Bindings.OpenXR/Generated


### PR DESCRIPTION
Segundo repo de la Fase 2, tras Vulkan.NET. Repunta CI y CD de `evergine-standards@v2` al toolbox `Evergine.Bindings@v1`, y añade `binding.yml`.

## Evidencia de que es un no-op

En Vulkan.NET se comparó el `.nupkg` del pipeline viejo contra el del nuevo. Resultado: **7 entradas idénticas con los mismos tamaños exactos**, y el ensamblado difiere en **147 bytes de 1.052.672 (0,014%)**, todos metadatos de build:

| Offset | Qué es |
|---|---|
| 136–140 | `TimeDateStamp` de la cabecera PE |
| 963240–963256 | MVID |
| 1048664–1048704 | `InformationalVersion 1.0.0+<sha>` |
| 1050200–1050467 | Directorio de debug y checksum del PDB |
| 1051672–1051751 | El mismo `1.0.0+<sha>` en UTF-16 |

Cero diferencias de código. Aquí se repetirá la misma comparación antes de mergear.

## Nota sobre el manifiesto

OpenXR-Docs sirve el registry desde **`master`**, no desde `main` como Vulkan-Docs. El manifiesto lo recoge explícitamente en vez de asumir que los dos repos de Khronos están organizados igual — el tipo de suposición que ya nos costó cinco meses de `Sync standards` en rojo.

## Rollback

`evergine-standards@v2` sigue intacto. Revertir este commit restaura el pipeline anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)