### PR TITLE
fix: declare the MIT licence the repository already carries

### DIFF
--- a/OpenXRGen/Evergine.Bindings.OpenXR/Evergine.Bindings.OpenXR.csproj
+++ b/OpenXRGen/Evergine.Bindings.OpenXR/Evergine.Bindings.OpenXR.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>

--- a/OpenXRGen/Evergine.Bindings.OpenXR/Evergine.Bindings.OpenXR.csproj
+++ b/OpenXRGen/Evergine.Bindings.OpenXR/Evergine.Bindings.OpenXR.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,7 @@
 		<Description>Low-level bindings for OpenXR used in Evergine</Description>
 		<RepositoryUrl>https://github.com/EvergineTeam/OpenXR.NET</RepositoryUrl>
 		<PackageIcon>icon.png</PackageIcon>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 


### PR DESCRIPTION
Every push to nuget.org warns `License missing` and the published package carries no licence expression, so nuget.org shows nothing where the licence link belongs and a compliance scanner has nothing to read. The repository has shipped an MIT `LICENSE` all along.

One of eight: the same line was missing from every published `Evergine.Bindings` package. Each repository's own `LICENSE` was read and confirmed MIT before writing it here, rather than assumed.

Verified on Cesium.NET by packing locally, where the nuspec then carried `<license type="expression">MIT</license>`.